### PR TITLE
fix `Parsers_File` handling

### DIFF
--- a/templates/etc/td-agent-bit/td-agent-bit.conf.j2
+++ b/templates/etc/td-agent-bit/td-agent-bit.conf.j2
@@ -28,7 +28,7 @@
     # parsers
     Parsers_File parsers.conf
 {% for parser in fluentbit_parser_files %}
-    Parsers_File {{ parser }}
+    Parsers_File {{ parser.name }}
 {% endfor %}
 
 {% if fluentbit_plugins | length() > 0 %}


### PR DESCRIPTION
Fix problem when you specify fluentbit_parser_files variable.
Only file name must be rendered in config file